### PR TITLE
fix: oom #329

### DIFF
--- a/.changeset/gorgeous-seals-lay.md
+++ b/.changeset/gorgeous-seals-lay.md
@@ -1,0 +1,6 @@
+---
+"@pkgr/rollup": patch
+"@pkgr/utils": patch
+---
+
+fix: only resolve package.json files for mono packages pattern - close #329

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "private": true,
   "workspaces": [
-    "packages/*"
+    "packages/**"
   ],
   "packageManager": "yarn@1.22.19",
   "scripts": {

--- a/packages/rollup/src/config.ts
+++ b/packages/rollup/src/config.ts
@@ -208,8 +208,14 @@ ConfigOptions = {}): RollupOptions[] => {
     monorepo === false
       ? [CWD]
       : Array.isArray(monorepo)
-      ? tryGlob(monorepo)
+      ? tryGlob(
+          monorepo.map(pkg =>
+            pkg.endsWith('/package.json') ? pkg : `${pkg}/package.json`,
+          ),
+        )
       : monorepoPkgs
+
+  pkgs = pkgs.map(pkg => pkg.replace(/\/package\.json$/, ''))
 
   if (monorepo == null && pkgs.length === 0) {
     pkgs = [CWD]

--- a/packages/utils/src/helpers.ts
+++ b/packages/utils/src/helpers.ts
@@ -69,23 +69,27 @@ export const tryGlob = (
     | {
         absolute?: boolean
         baseDir?: string
+        ignore?: [string]
       } = {},
 ) => {
-  const { absolute = true, baseDir = CWD } =
-    typeof options === 'string' ? { baseDir: options } : options
+  const {
+    absolute = true,
+    baseDir = CWD,
+    ignore = ['**/node_modules/**'],
+  } = typeof options === 'string' ? { baseDir: options } : options
   return paths.reduce<string[]>(
-    (acc, pkg) => {
-      const pkgJsonPath = `${pkg}/package.json`;
-      return [
+    (acc, pkg) =>
+      [
         ...acc,
         ...(isGlob(pkg)
-          ? tryRequirePkg<typeof import('fast-glob')>('fast-glob')!.sync(pkgJsonPath, {
+          ? tryRequirePkg<typeof import('fast-glob')>('fast-glob')!.sync(pkg, {
               absolute,
               cwd: baseDir,
+              ignore,
+              onlyFiles: false,
             })
-          : [tryFile(path.resolve(baseDir, pkgJsonPath), true)]),
-      ].filter(Boolean)
-    },
+          : [tryFile(path.resolve(baseDir, pkg), true)]),
+      ].filter(Boolean),
     [],
   )
 }

--- a/packages/utils/src/helpers.ts
+++ b/packages/utils/src/helpers.ts
@@ -74,17 +74,18 @@ export const tryGlob = (
   const { absolute = true, baseDir = CWD } =
     typeof options === 'string' ? { baseDir: options } : options
   return paths.reduce<string[]>(
-    (acc, pkg) =>
-      [
+    (acc, pkg) => {
+      const pkgJsonPath = `${pkg}/package.json`;
+      return [
         ...acc,
         ...(isGlob(pkg)
-          ? tryRequirePkg<typeof import('fast-glob')>('fast-glob')!.sync(pkg, {
+          ? tryRequirePkg<typeof import('fast-glob')>('fast-glob')!.sync(pkgJsonPath, {
               absolute,
               cwd: baseDir,
-              onlyFiles: false,
             })
-          : [tryFile(path.resolve(baseDir, pkg), true)]),
-      ].filter(Boolean),
+          : [tryFile(path.resolve(baseDir, pkgJsonPath), true)]),
+      ].filter(Boolean)
+    },
     [],
   )
 }

--- a/packages/utils/src/monorepo.ts
+++ b/packages/utils/src/monorepo.ts
@@ -12,4 +12,10 @@ const pkgsPath = lernaConfig.packages ?? pkg.workspaces ?? []
 
 export const isMonorepo = Array.isArray(pkgsPath) && pkgsPath.length > 0
 
-export const monorepoPkgs = isMonorepo ? tryGlob(pkgsPath) : []
+export const monorepoPkgs = isMonorepo
+  ? tryGlob(
+      pkgsPath.map(pkg =>
+        pkg.endsWith('/package.json') ? pkg : `${pkg}/package.json`,
+      ),
+    )
+  : []


### PR DESCRIPTION
for given workspaces config:

```json
{
	"workspace": [ "packages/**" ]
}
```

should only search `fastGlob('packages/**/package.json')` instead of `fastGlob('packages/**')`

close #329

close un-ts/synckit#134

close ota-meshi/eslint-plugin-json-schema-validator#220