### PR TITLE
fix(core): suppprt run with `node --eval`

### DIFF
--- a/.changeset/giant-walls-punch.md
+++ b/.changeset/giant-walls-punch.md
@@ -1,0 +1,5 @@
+---
+"@pkgr/core": patch
+---
+
+fix(core): suppprt run with `node --eval`

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -9,7 +9,9 @@ export interface CjsRequire extends NodeJS.Require {
 }
 
 export const cjsRequire: CjsRequire =
-  typeof require === 'undefined' ? createRequire(import.meta.url) : require
+  typeof require === 'undefined' || __filename === '[eval]'
+    ? createRequire(import.meta.url)
+    : require
 
 // eslint-disable-next-line sonarjs/deprecation
 export const EXTENSIONS = ['.ts', '.tsx', ...Object.keys(cjsRequire.extensions)]


### PR DESCRIPTION
related https://github.com/un-ts/eslint-plugin-import-x/issues/296

<!-- ELLIPSIS_HIDDEN -->

> [!IMPORTANT]
> Fixes `cjsRequire` in `constants.ts` to support `node --eval` by using `createRequire` when `__filename` is '[eval]'.
> 
>   - **Behavior**:
>     - Fixes `cjsRequire` in `constants.ts` to support running with `node --eval` by checking if `__filename` is '[eval]'.
>     - Uses `createRequire(import.meta.url)` when `require` is undefined or `__filename` is '[eval]'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Fpkgr&utm_source=github&utm_medium=referral)<sup> for 9627e920724f1b175e86af1092147c48fc5c4f0c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->