### PR TITLE
fix(core): `findUp` should not stop on `CWD`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,7 +9,7 @@
   "commit": false,
   "linked": [],
   "access": "restricted",
-  "baseBranch": "master",
+  "baseBranch": "core-0.2.x",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/.changeset/old-lions-travel.md
+++ b/.changeset/old-lions-travel.md
@@ -1,0 +1,5 @@
+---
+"@pkgr/core": patch
+---
+
+fix: `findUp` should not stop on `CWD`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - core-0.2.x
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:es": "eslint . --cache",
     "lint:tsc": "tsc --noEmit",
     "prepare": "simple-git-hooks && yarn-berry-deduplicate || exit 0",
-    "release": "changeset publish",
+    "release": "changeset publish --tag release-0.2",
     "test": "vitest run",
     "typecov": "type-coverage",
     "version": "changeset version && yarn --no-immutable"

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -44,15 +44,6 @@ export const findUp = (
   searchFileOrIncludeDir?: boolean | string,
   includeDir?: boolean,
 ) => {
-  console.assert(path.isAbsolute(searchEntry))
-
-  if (
-    !tryFile(searchEntry, true) ||
-    (searchEntry !== CWD && !searchEntry.startsWith(CWD + path.sep))
-  ) {
-    return ''
-  }
-
   searchEntry = path.resolve(
     fs.statSync(searchEntry).isDirectory()
       ? searchEntry
@@ -63,16 +54,20 @@ export const findUp = (
 
   const searchFile = isSearchFile ? searchFileOrIncludeDir : 'package.json'
 
+  let lastSearchEntry: string | undefined
+
   do {
     const searched = tryFile(
-      path.resolve(searchEntry, searchFile),
+      searchFile,
       isSearchFile && includeDir,
+      searchEntry,
     )
     if (searched) {
       return searched
     }
+    lastSearchEntry = searchEntry
     searchEntry = path.resolve(searchEntry, '..')
-  } while (searchEntry === CWD || searchEntry.startsWith(CWD + path.sep))
+  } while (!lastSearchEntry || lastSearchEntry !== searchEntry)
 
   return ''
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix `findUp` in `helpers.ts` to not stop at CWD and update release process configurations.
> 
>   - **Behavior**:
>     - Fix `findUp` in `helpers.ts` to not stop at `CWD` by removing the condition that checks for `CWD`.
>   - **Release Process**:
>     - Update `release.yml` to trigger on `core-0.2.x` branch instead of `master`.
>     - Modify `release` script in `package.json` to include `--tag release-0.2`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Fpkgr&utm_source=github&utm_medium=referral)<sup> for cfbd42f31b2f873417552f9a3cce0c6193829181. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->