### PR TITLE
fix(core): `findUp` should never throw

### DIFF
--- a/.changeset/quick-pens-reply.md
+++ b/.changeset/quick-pens-reply.md
@@ -1,0 +1,5 @@
+---
+"@pkgr/core": patch
+---
+
+fix: `findUp` should never throw

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -44,12 +44,6 @@ export const findUp = (
   searchFileOrIncludeDir?: boolean | string,
   includeDir?: boolean,
 ) => {
-  searchEntry = path.resolve(
-    fs.statSync(searchEntry).isDirectory()
-      ? searchEntry
-      : path.resolve(searchEntry, '..'),
-  )
-
   const isSearchFile = typeof searchFileOrIncludeDir === 'string'
 
   const searchFile = isSearchFile ? searchFileOrIncludeDir : 'package.json'
@@ -66,7 +60,7 @@ export const findUp = (
       return searched
     }
     lastSearchEntry = searchEntry
-    searchEntry = path.resolve(searchEntry, '..')
+    searchEntry = path.dirname(searchEntry)
   } while (!lastSearchEntry || lastSearchEntry !== searchEntry)
 
   return ''


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplifies `findUp` in `helpers.ts` to prevent errors by removing `fs.statSync` and using `path.dirname`.
> 
>   - **Behavior**:
>     - `findUp` in `helpers.ts` no longer uses `fs.statSync` to resolve `searchEntry`, preventing potential errors.
>     - Replaces `path.resolve(searchEntry, '..')` with `path.dirname(searchEntry)` to simplify directory traversal logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Fpkgr&utm_source=github&utm_medium=referral)<sup> for 56b0801bf4ed68dcfedc2e668252a27e8708cce1. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->