### PR TITLE
fix(core): handle findUp `options` correctly

### DIFF
--- a/.changeset/tasty-mayflies-build.md
+++ b/.changeset/tasty-mayflies-build.md
@@ -1,0 +1,5 @@
+---
+"@pkgr/core": patch
+---
+
+fix: hadnle findUp `options` correctly

--- a/.changeset/tasty-mayflies-build.md
+++ b/.changeset/tasty-mayflies-build.md
@@ -2,4 +2,4 @@
 "@pkgr/core": patch
 ---
 
-fix: hadnle findUp `options` correctly
+fix: handle findUp `options` correctly

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -90,6 +90,8 @@ export const findUp = (
       entry: entryOrOptions,
       ...options,
     }
+  } else if (entryOrOptions) {
+    options = options ? { ...entryOrOptions, ...options } : entryOrOptions
   }
 
   let { entry = CWD, search = 'package.json', type, stop } = options ?? {}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes handling of `options` in `findUp` function to correctly merge `entryOrOptions` with `options`.
> 
>   - **Behavior**:
>     - Fixes handling of `options` in `findUp` function in `helpers.ts` to correctly merge `entryOrOptions` with `options` when `entryOrOptions` is not a string.
>   - **Misc**:
>     - Adds changeset `tasty-mayflies-build.md` for patch update of `@pkgr/core`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Fpkgr&utm_source=github&utm_medium=referral)<sup> for c329fe324005272f3a614f20a35be8a46e0b0fe6. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->